### PR TITLE
Remove Telegram from Chat list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -107,7 +107,6 @@ Hide your IP address
 
 ### Chat
 
-- [Telegram](https://telegram.org/) - Heavily encrypted and self-destructing messages.
 - [Signal](https://whispersystems.org/) - Free peer reviewed scalable encryption chat.
 - [Wire](https://wire.com) - End-to-end chats,calls and documents.
 


### PR DESCRIPTION
Telegram uses MTProto, a custom encryption protocol that has received criticism from security experts \[[1][1],[2][2]\], and has several know issues \[[3][3],[4][4]\].

Also, by default private chats on Telegram are not encrypted, and group chats are never encrypted \[[5][5],[6][6]\].

Because of these reasons, I believe Telegram should not be endorsed on a list about privacy respecting software.

 [1]: https://en.wikipedia.org/wiki/Telegram_(software)#Security
 [2]: https://crypto.stackexchange.com/questions/31418/signal-vs-telegram-in-terms-of-protocols
 [3]: https://caislab.kaist.ac.kr/publication/paper_files/2017/SCIS17_JU.pdf
 [4]: http://delivery.acm.org/10.1145/3000000/2994468/p113-jakobsen.pdf
 [5]: https://telegram.org/faq#q-what-if-im-more-paranoid-than-your-regular-user
 [6]: https://telegra.ph/Why-Isnt-Telegram-End-to-End-Encrypted-by-Default-08-14