### PR TITLE
Adding pivx2bitcoin private crypto swap

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -211,6 +211,7 @@ Hide your IP address
 - [List of cryptocurrencies (wikipedia)](https://en.wikipedia.org/wiki/List_of_cryptocurrencies)
 - [Over the counter btc](https://bitcoin-otc.com/) - Marketplace for people to conduct over-the-counter trading in bitcoin currency.
 - [CoinJoin](https://en.bitcoin.it/wiki/CoinJoin) - Bitcoin transaction compression which aims to improve privacy.
+- [pivx2bitcoin](https://pivx2bitcoin.com) - Private crypto swap. No accounts, no signups, no JavaScript, no tracking, no analytics. Hosted on Tor and clearnet.
 
 ## File hosting
 


### PR DESCRIPTION
Adds pivx2bitcoin. An anonymous crypto swap with no accounts, no JavaScript, and no tracking. Hosted on Tor as well as clearnet, and VPN friendly.