### PR TITLE
Add MetaClean

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -178,6 +178,7 @@ Hide your IP address
 ### Image
 
   - [ExifCleaner](https://exifcleaner.com/) - Open source app to remove exif metadata from images.
+  - [MetaClean](https://github.com/Moresyl/metaclean) - Open source offline desktop app for inspecting and removing metadata from images, Office documents, PDFs, and text files.
 
 ### Video
 


### PR DESCRIPTION
Add MetaClean next to ExifCleaner in the existing Communication > Image section. MetaClean is an open-source offline desktop app that removes metadata from images and other common document formats.